### PR TITLE
fix: key-value-store APIs - remove query parameters

### DIFF
--- a/openapi/paths/v2@key-value-stores.yaml
+++ b/openapi/paths/v2@key-value-stores.yaml
@@ -8,23 +8,13 @@ get:
     The response is a list of objects, where each objects contains a basic
     information about a single key-value store.
 
-
     The endpoint supports pagination using the `limit` and `offset` parameters
-    and it will not return more than 1000
-
-    array elements.
-
+    and it will not return more than 1000 array elements.
 
     By default, the records are sorted by the `createdAt` field in ascending
-    order,
-
-    therefore you can use pagination to incrementally fetch all key-value stores
-    while new
-
-    ones are still being created. To sort the records in descending order, use
-    the `desc=1`
-
-    parameter.
+    order, therefore you can use pagination to incrementally fetch all key-value stores
+    while new ones are still being created. To sort the records in descending order, use
+    the `desc=1` parameter.
   operationId: Getlistofkey-valuestores
   parameters:
     - name: token
@@ -78,13 +68,6 @@ get:
       schema:
         type: boolean
         example: true
-    - name: name
-      in: query
-      description: ''
-      style: form
-      explode: true
-      schema:
-        type: string
   responses:
     '200':
       description: ''
@@ -153,14 +136,11 @@ post:
   summary: Create key-value store
   description: >-
     Creates a key-value store and returns its object. The response is the same
-    object as returned
-
-    by the [Get store](#reference/key-value-stores/store-object/get-store)
+    object as returned by the [Get store](#reference/key-value-stores/store-object/get-store)
     endpoint.
 
     Keep in mind that data stored under unnamed store follows [data retention
     period](https://docs.apify.com/platform/storage#data-retention).
-
 
     It creates a store with the given name if the parameter name is used.
 
@@ -185,34 +165,6 @@ post:
       schema:
         type: string
         example: eshop-values
-    - name: limit
-      in: query
-      description: ''
-      style: form
-      explode: true
-      schema:
-        type: string
-    - name: offset
-      in: query
-      description: ''
-      style: form
-      explode: true
-      schema:
-        type: string
-    - name: desc
-      in: query
-      description: ''
-      style: form
-      explode: true
-      schema:
-        type: string
-    - name: unnamed
-      in: query
-      description: ''
-      style: form
-      explode: true
-      schema:
-        type: string
   responses:
     '201':
       description: ''


### PR DESCRIPTION
Key-value-store APIs - remove query parameters that are not present in the API blueprint