### PR TITLE
test: Legacy Doc Link decorator basic acceptance test

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,7 @@
+#!/usr/bin/env -S npx bats
+
+@test "The bundled OAI document should contain Legacy Doc link fragment:" {
+  cat openapi.yaml | grep -F '<span id="/reference/logs/log/get-log">'
+}
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.0.48",
       "dependencies": {
         "@redocly/cli": "^1.16.0"
+      },
+      "devDependencies": {
+        "bats": "^1.11.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -305,6 +308,16 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/bats": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.11.0.tgz",
+      "integrity": "sha512-qiKdnS4ID3bJ1MaEOKuZe12R4w+t+psJF0ICj+UdkiHBBoObPMHv8xmD3w6F4a5qwUyZUHS+413lxENBNy8xcQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "bats": "bin/bats"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   "scripts": {
     "start": "redocly preview-docs",
     "build": "redocly bundle -o openapi",
-    "test": "redocly lint && redocly bundle -o openapi && bin/schemathesis"
+    "test": "redocly lint && redocly bundle -o openapi && ./bin/test && bin/schemathesis"
   },
-  "packageManager": "yarn@1.22.22"
+  "packageManager": "yarn@1.22.22",
+  "devDependencies": {
+    "bats": "^1.11.0"
+  }
 }


### PR DESCRIPTION
I saw the test fail (screenshot below) and [pass](https://github.com/apify/openapi/actions/runs/9743336521/job/26886551801#step:7:1413). Connected to #19 

<img width="922" alt="Screenshot 2024-07-01 at 12 57 13" src="https://github.com/apify/openapi/assets/79609/384679b4-bf6b-4ba9-a8a4-6c8f0cb76b05">

