### PR TITLE
fix: Removed specifc version from the OpenAPI Document

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -601,7 +601,7 @@ info:
     - `~resourcename` - for this, you need to use an API token, and the
     `resourcename` refers to a resource in the API token owner's account.
   contact: {}
-  version: '1.0'
+  version: ''
 servers:
   - url: 'https://api.apify.com'
     variables: {}


### PR DESCRIPTION
This fixes the title with wrong version (1.0).

After this fix:
![Screenshot 2024-07-29 at 12 52 33](https://github.com/user-attachments/assets/03ad4cb0-1b4e-45e0-b26d-c8ae4e6f9ea5)

Before this fix:
![Screenshot 2024-07-29 at 12 53 20](https://github.com/user-attachments/assets/60cfaae8-cb3f-4864-98da-dc3936e3acf2)
