### PR TITLE
fix: pin `schemathesis` version in CI checks

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-      - run: python -m pip install schemathesis
+      - run: python -m pip install schemathesis==3.35.0
       - run: npm install
       - run: npm run build
       - run: npm run test


### PR DESCRIPTION
As described at https://github.com/schemathesis/schemathesis/issues/2462, `schemathesis@3.36.0` introduces a bug regarding the `invalid_auth` tests. This should have been fixed by https://github.com/schemathesis/schemathesis/pull/2463, but the issue is still present in `3.37.0`.

This correlates with the failing `Check` workflow in the GitHub Actions of this repo. Pinning the package version to the latest known working version (`3.35.0`) makes the CI pass again.

Unblocks #98 #100 