### PR TITLE
docs(api): Add missing update users limits endpoint

### DIFF
--- a/openapi/components/schemas/users/UpdateLimitsRequest.yaml
+++ b/openapi/components/schemas/users/UpdateLimitsRequest.yaml
@@ -1,0 +1,16 @@
+title: UpdateLimitsRequest
+type: object
+properties:
+  maxMonthlyUsageUsd:
+    type: number
+    example: 300
+    description: |
+      If your platform usage in the billing period exceeds the prepaid usage, you will be charged extra.
+      Setting this property you can update your hard limit on monthly platform usage to prevent accidental overage or to limit the extra charges
+  dataRetentionDays:
+    type: number
+    example: 90
+    description: |
+      Apify securely stores your ten most recent Actor runs indefinitely, ensuring they are always accessible.
+      Unnamed storages and other Actor runs are automatically deleted after the retention period.
+      If you're subscribed, you can change it to keep data for longer or to limit your usage. [Lear more](https://docs.apify.com/platform/storage/usage#data-retention)

--- a/openapi/paths/users/users@me@limits.yaml
+++ b/openapi/paths/users/users@me@limits.yaml
@@ -18,3 +18,26 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/users/account-and-usage-limits/get-limits
+put:
+  tags:
+    - Users/Account and usage limits
+  summary: Update limits
+  description: |
+    Updates the account's limits manageable on your account's [Limits page](https://console.apify.com/billing#/limits).
+    Specifically the: `maxMonthlyUsageUsd` and `dataRetentionDays` limits (see request body schema for more details).
+  operationId: users_me_limits_put
+  requestBody:
+    description: ''
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/users/UpdateLimitsRequest.yaml
+  responses:
+    '201':
+      description: ''
+      headers: {}
+      content:
+          application/json:
+            schema:
+              type: object
+  deprecated: false


### PR DESCRIPTION
Add `PUT: /v2/users/me/limits` to docs (ep already exists in api, but was not documented yet.)
Resolves: https://github.com/apify/apify-client-js/issues/329

- console docs PR: https://github.com/apify/apify-core/pull/18038
- JS client PR: https://github.com/apify/apify-client-js/pull/595
- python client https://github.com/apify/apify-client-python/pull/279