### PR TITLE
Fix: Support for legacy permalinks omitting the colleection/object part.

### DIFF
--- a/openapi/components/tags.yaml
+++ b/openapi/components/tags.yaml
@@ -133,8 +133,6 @@
 - name: Actors/Abort build
   x-displayName: Abort build
   x-parent-tag-name: Actors
-  x-legacy-doc-urls:
-  - '#/reference/actors/abort-build'
   x-trait: 'true'
   description: '**[DEPRECATED]** API endpoints related to build of the actor were
     moved under new namespace [`actor-builds`](#/reference/actor-builds).'
@@ -167,24 +165,18 @@
 - name: Actors/Abort run
   x-displayName: Abort run
   x-parent-tag-name: Actors
-  x-legacy-doc-urls:
-  - '#/reference/actors/abort-run'
   x-trait: 'true'
   description: '**[DEPRECATED]** API endpoints related to run of the actor were moved
     under new namespace [`actor-runs`](#/reference/actor-runs).'
 - name: Actors/Metamorph run
   x-displayName: Metamorph run
   x-parent-tag-name: Actors
-  x-legacy-doc-urls:
-  - '#/reference/actors/metamorph-run'
   x-trait: 'true'
   description: '**[DEPRECATED]** API endpoints related to run of the actor were moved
     under new namespace [`actor-runs`](#/reference/actor-runs).'
 - name: Actors/Resurrect run
   x-displayName: Resurrect run
   x-parent-tag-name: Actors
-  x-legacy-doc-urls:
-  - '#/reference/actors/resurrect-run'
   x-trait: 'true'
   description: '**[DEPRECATED]** API endpoints related to run of the actor were moved
     under new namespace [`actor-runs`](#/reference/actor-runs).'
@@ -609,38 +601,26 @@
 - name: Actor runs/Delete run
   x-displayName: Delete run
   x-parent-tag-name: Actor runs
-  x-legacy-doc-urls:
-  - '#/reference/actor-runs/delete-run'
   x-trait: 'true'
 - name: Actor runs/Abort run
   x-displayName: Abort run
   x-parent-tag-name: Actor runs
-  x-legacy-doc-urls:
-  - '#/reference/actor-runs/abort-run'
   x-trait: 'true'
 - name: Actor runs/Metamorph run
   x-displayName: Metamorph run
   x-parent-tag-name: Actor runs
-  x-legacy-doc-urls:
-  - '#/reference/actor-runs/metamorph-run'
   x-trait: 'true'
 - name: Actor runs/Reboot run
   x-displayName: Reboot run
   x-parent-tag-name: Actor runs
-  x-legacy-doc-urls:
-  - '#/reference/actor-runs/reboot-run'
   x-trait: 'true'
 - name: Actor runs/Resurrect run
   x-displayName: Resurrect run
   x-parent-tag-name: Actor runs
-  x-legacy-doc-urls:
-  - '#/reference/actor-runs/resurrect-run'
   x-trait: 'true'
 - name: Actor runs/Update status message
   x-displayName: Update status message
   x-parent-tag-name: Actor runs
-  x-legacy-doc-urls:
-  - '#/reference/actor-runs/update-status-message'
   x-trait: 'true'
 - name: Actor builds
   x-displayName: Actor builds
@@ -672,14 +652,10 @@
 - name: Actor builds/Delete build
   x-displayName: Delete build
   x-parent-tag-name: Actor builds
-  x-legacy-doc-urls:
-  - '#/reference/actor-builds/delete-build'
   x-trait: 'true'
 - name: Actor builds/Abort build
   x-displayName: Abort build
   x-parent-tag-name: Actor builds
-  x-legacy-doc-urls:
-  - '#/reference/actor-builds/abort-build'
   x-trait: 'true'
 - name: Actor builds/Build log
   x-displayName: Build log

--- a/openapi/paths/actor-builds/actor-builds.yaml
+++ b/openapi/paths/actor-builds/actor-builds.yaml
@@ -4,6 +4,7 @@ get:
   summary: Get user builds list
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-builds/build-collection/get-user-builds-list
+    - https://docs.apify.com/api/v2#/reference/actor-builds/get-user-builds-list
   description: |
     Gets a list of all builds for a user. The response is a JSON array of
     objects, where each object contains basic information about a single build.

--- a/openapi/paths/actor-builds/actor-builds@{buildId}.yaml
+++ b/openapi/paths/actor-builds/actor-builds@{buildId}.yaml
@@ -53,6 +53,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-builds/build-object/get-build
+    - https://docs.apify.com/api/v2#/reference/actor-builds/get-build
   x-js-parent: BuildClient
   x-js-name: get
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/BuildClient#get
@@ -86,6 +87,7 @@ delete:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-builds/delete-build/delete-build
+    - https://docs.apify.com/api/v2#/reference/actor-builds/delete-build
   x-js-parent: BuildClient
   x-js-name: delete
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/BuildClient#delete

--- a/openapi/paths/actor-builds/actor-builds@{buildId}.yaml
+++ b/openapi/paths/actor-builds/actor-builds@{buildId}.yaml
@@ -62,7 +62,8 @@ get:
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/BuildClientAsync#get
 delete:
   tags:
-    - Actor builds/Delete build
+    #- Actor builds/Delete build
+    - Actor builds
   summary: Delete build
   description: |
     Delete the build. The build that is the current default build for the Actor

--- a/openapi/paths/actor-builds/actor-builds@{buildId}@abort.yaml
+++ b/openapi/paths/actor-builds/actor-builds@{buildId}@abort.yaml
@@ -30,6 +30,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-builds/abort-build/abort-build
+    - https://docs.apify.com/api/v2#/reference/actor-builds/abort-build
   x-js-parent: BuildClient
   x-js-name: abort
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/BuildClient#abort

--- a/openapi/paths/actor-builds/actor-builds@{buildId}@log.yaml
+++ b/openapi/paths/actor-builds/actor-builds@{buildId}@log.yaml
@@ -55,3 +55,4 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-builds/build-log/get-log
+    - https://docs.apify.com/api/v2#/reference/actor-builds/get-log

--- a/openapi/paths/actor-runs/actor-runs.yaml
+++ b/openapi/paths/actor-runs/actor-runs.yaml
@@ -107,3 +107,4 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-runs/run-collection/get-user-runs-list
+    - https://docs.apify.com/api/v2#/reference/actor-runs/get-user-runs-list

--- a/openapi/paths/actor-runs/actor-runs@{runId}.yaml
+++ b/openapi/paths/actor-runs/actor-runs@{runId}.yaml
@@ -182,6 +182,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-runs/run-object-and-its-storages/get-run
+    - https://docs.apify.com/api/v2#/reference/actor-runs/get-run
 delete:
   tags:
     - Actor runs/Delete run
@@ -207,6 +208,7 @@ delete:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-runs/delete-run/delete-run
+    - https://docs.apify.com/api/v2#/reference/actor-runs/delete-run
   x-js-parent: RunClient
   x-js-name: delete
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RunClient#delete
@@ -332,3 +334,4 @@ put:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-runs/update-status-message/update-status-message
+    - https://docs.apify.com/api/v2#/reference/actor-runs/update-status-message

--- a/openapi/paths/actor-runs/actor-runs@{runId}@abort.yaml
+++ b/openapi/paths/actor-runs/actor-runs@{runId}@abort.yaml
@@ -110,6 +110,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-runs/abort-run/abort-run
+    - https://docs.apify.com/api/v2#/reference/actor-runs/abort-run
   x-js-parent: RunClient
   x-js-name: abort
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RunClient#abort

--- a/openapi/paths/actor-runs/actor-runs@{runId}@metamorph.yaml
+++ b/openapi/paths/actor-runs/actor-runs@{runId}@metamorph.yaml
@@ -138,6 +138,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-runs/metamorph-run/metamorph-run
+    - https://docs.apify.com/api/v2#/reference/actor-runs/metamorph-run
   x-js-parent: RunClient
   x-js-name: metamorph
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RunClient#metamorph

--- a/openapi/paths/actor-runs/actor-runs@{runId}@reboot.yaml
+++ b/openapi/paths/actor-runs/actor-runs@{runId}@reboot.yaml
@@ -103,6 +103,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-runs/reboot-run/reboot-run
+    - https://docs.apify.com/api/v2#/reference/actor-runs/reboot-run
   x-js-parent: RunClient
   x-js-name: reboot
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RunClient#reboot

--- a/openapi/paths/actor-runs/actor-runs@{runId}@resurrect.yaml
+++ b/openapi/paths/actor-runs/actor-runs@{runId}@resurrect.yaml
@@ -123,6 +123,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-runs/resurrect-run/resurrect-run
+    - https://docs.apify.com/api/v2#/reference/actor-runs/resurrect-run
   x-js-parent: RunClient
   x-js-name: resurrect
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RunClient#resurrect

--- a/openapi/paths/actor-tasks/actor-tasks.yaml
+++ b/openapi/paths/actor-tasks/actor-tasks.yaml
@@ -101,6 +101,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-tasks/task-collection/get-list-of-tasks
+    - https://docs.apify.com/api/v2#/reference/actor-tasks/get-list-of-tasks
   x-js-parent: TaskCollectionClient
   x-js-name: list
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/TaskCollectionClient#list
@@ -188,6 +189,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-tasks/task-collection/create-task
+    - https://docs.apify.com/api/v2#/reference/actor-tasks/create-task
   x-js-parent: TaskCollectionClient
   x-js-name: create
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/TaskCollectionClient#create

--- a/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}.yaml
+++ b/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}.yaml
@@ -47,6 +47,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-tasks/task-object/get-task
+    - https://docs.apify.com/api/v2#/reference/actor-tasks/get-task
   x-js-parent: TaskClient
   x-js-name: get
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/TaskClient#get
@@ -140,6 +141,7 @@ put:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-tasks/task-object/update-task
+    - https://docs.apify.com/api/v2#/reference/actor-tasks/update-task
   x-js-parent: TaskClient
   x-js-name: update
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/TaskClient#update
@@ -173,6 +175,7 @@ delete:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-tasks/task-object/delete-task
+    - https://docs.apify.com/api/v2#/reference/actor-tasks/delete-task
   x-js-parent: TaskClient
   x-js-name: delete
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/TaskClient#delete

--- a/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@input.yaml
+++ b/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@input.yaml
@@ -28,6 +28,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-tasks/task-input-object/get-task-input
+    - https://docs.apify.com/api/v2#/reference/actor-tasks/get-task-input
   x-js-parent: TaskClient
   x-js-name: getInput
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/TaskClient#getInput
@@ -88,6 +89,7 @@ put:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-tasks/task-input-object/update-task-input
+    - https://docs.apify.com/api/v2#/reference/actor-tasks/update-task-input
   x-js-parent: TaskClient
   x-js-name: updateInput
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/TaskClient#updateInput

--- a/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@run-sync-get-dataset-items.yaml
+++ b/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@run-sync-get-dataset-items.yaml
@@ -398,6 +398,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-tasks/run-task-synchronously-and-get-dataset-items/run-task-synchronously-and-get-dataset-items-post
+    - https://docs.apify.com/api/v2#/reference/actor-tasks/run-task-synchronously-and-get-dataset-items-post
 get:
   tags:
     - Actor tasks/Run task synchronously and get dataset items
@@ -784,3 +785,4 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-tasks/run-task-synchronously-and-get-dataset-items/run-task-synchronously-and-get-dataset-items-get
+    - https://docs.apify.com/api/v2#/reference/actor-tasks/run-task-synchronously-and-get-dataset-items-get

--- a/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@run-sync.yaml
+++ b/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@run-sync.yaml
@@ -144,6 +144,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-tasks/run-task-synchronously/run-task-synchronously-post
+    - https://docs.apify.com/api/v2#/reference/actor-tasks/run-task-synchronously-post
 get:
   tags:
     - Actor tasks/Run task synchronously
@@ -276,3 +277,4 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-tasks/run-task-synchronously/run-task-synchronously-get
+    - https://docs.apify.com/api/v2#/reference/actor-tasks/run-task-synchronously-get

--- a/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs.yaml
+++ b/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@runs.yaml
@@ -125,6 +125,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-tasks/run-collection/get-list-of-task-runs
+    - https://docs.apify.com/api/v2#/reference/actor-tasks/get-list-of-task-runs
 post:
   tags:
     - Actor tasks/Run collection
@@ -351,6 +352,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-tasks/run-collection/run-task
+    - https://docs.apify.com/api/v2#/reference/actor-tasks/run-task
   x-js-parent: TaskClient
   x-js-name: start
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/TaskClient#start

--- a/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@webhooks.yaml
+++ b/openapi/paths/actor-tasks/actor-tasks@{actorTaskId}@webhooks.yaml
@@ -132,3 +132,4 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actor-tasks/webhook-collection/get-list-of-webhooks
+    - https://docs.apify.com/api/v2#/reference/actor-tasks/get-list-of-webhooks

--- a/openapi/paths/actors/acts.yaml
+++ b/openapi/paths/actors/acts.yaml
@@ -87,6 +87,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/actor-collection/get-list-of-actors
+    - https://docs.apify.com/api/v2#/reference/actors/get-list-of-actors
   x-js-parent: ActorCollectionClient
   x-js-name: list
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/ActorCollectionClient#list
@@ -231,6 +232,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/actor-collection/create-actor
+    - https://docs.apify.com/api/v2#/reference/actors/create-actor
   x-js-parent: ActorCollectionClient
   x-js-name: create
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/ActorCollectionClient#create

--- a/openapi/paths/actors/acts@{actorId}.yaml
+++ b/openapi/paths/actors/acts@{actorId}.yaml
@@ -84,6 +84,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/actor-object/get-actor
+    - https://docs.apify.com/api/v2#/reference/actors/get-actor
   x-js-parent: ActorClient
   x-js-name: get
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/ActorClient#get
@@ -234,6 +235,7 @@ put:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/actor-object/update-actor
+    - https://docs.apify.com/api/v2#/reference/actors/update-actor
   x-js-parent: ActorClient
   x-js-name: update
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/ActorClient#update
@@ -268,6 +270,7 @@ delete:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/actor-object/delete-actor
+    - https://docs.apify.com/api/v2#/reference/actors/delete-actor
   x-js-parent: ActorClient
   x-js-name: delete
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/ActorClient#delete

--- a/openapi/paths/actors/acts@{actorId}@builds.yaml
+++ b/openapi/paths/actors/acts@{actorId}@builds.yaml
@@ -66,6 +66,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/build-collection/get-list-of-builds
+    - https://docs.apify.com/api/v2#/reference/actors/get-list-of-builds
   x-js-parent: BuildCollectionClient
   x-js-name: list
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/BuildCollectionClient#list
@@ -190,6 +191,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/build-collection/build-actor
+    - https://docs.apify.com/api/v2#/reference/actors/build-actor
   x-js-parent: ActorClient
   x-js-name: build
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/ActorClient#build

--- a/openapi/paths/actors/acts@{actorId}@builds@{buildId}.yaml
+++ b/openapi/paths/actors/acts@{actorId}@builds@{buildId}.yaml
@@ -92,3 +92,4 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/build-object/get-build
+    - https://docs.apify.com/api/v2#/reference/actors/get-build

--- a/openapi/paths/actors/acts@{actorId}@builds@{buildId}@abort.yaml
+++ b/openapi/paths/actors/acts@{actorId}@builds@{buildId}@abort.yaml
@@ -61,3 +61,4 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/abort-build/abort-build
+    - https://docs.apify.com/api/v2#/reference/actors/abort-build

--- a/openapi/paths/actors/acts@{actorId}@run-sync-get-dataset-items.yaml
+++ b/openapi/paths/actors/acts@{actorId}@run-sync-get-dataset-items.yaml
@@ -424,6 +424,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/run-actor-synchronously-and-get-dataset-items/run-actor-synchronously-with-input-and-get-dataset-items
+    - https://docs.apify.com/api/v2#/reference/actors/run-actor-synchronously-with-input-and-get-dataset-items
 get:
   tags:
     - Actors/Run Actor synchronously and get dataset items
@@ -828,3 +829,4 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/run-actor-synchronously-and-get-dataset-items/run-actor-synchronously-without-input-and-get-dataset-items
+    - https://docs.apify.com/api/v2#/reference/actors/run-actor-synchronously-without-input-and-get-dataset-items

--- a/openapi/paths/actors/acts@{actorId}@run-sync.yaml
+++ b/openapi/paths/actors/acts@{actorId}@run-sync.yaml
@@ -160,6 +160,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/run-actor-synchronously/with-input
+    - https://docs.apify.com/api/v2#/reference/actors/with-input
 get:
   tags:
     - Actors/Run actor synchronously
@@ -306,3 +307,4 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/run-actor-synchronously/without-input
+    - https://docs.apify.com/api/v2#/reference/actors/without-input

--- a/openapi/paths/actors/acts@{actorId}@runs.yaml
+++ b/openapi/paths/actors/acts@{actorId}@runs.yaml
@@ -115,6 +115,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/run-collection/get-list-of-runs
+    - https://docs.apify.com/api/v2#/reference/actors/get-list-of-runs
   x-js-parent: RunCollectionClient
   x-js-name: list
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RunCollectionClient#list
@@ -330,6 +331,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/run-collection/run-actor
+    - https://docs.apify.com/api/v2#/reference/actors/run-actor
   x-js-parent: ActorClient
   x-js-name: start
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/ActorClient#start

--- a/openapi/paths/actors/acts@{actorId}@runs@last.yaml
+++ b/openapi/paths/actors/acts@{actorId}@runs@last.yaml
@@ -215,3 +215,4 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/last-run-object-and-its-storages/get-last-run
+    - https://docs.apify.com/api/v2#/reference/actors/get-last-run

--- a/openapi/paths/actors/acts@{actorId}@runs@{runId}.yaml
+++ b/openapi/paths/actors/acts@{actorId}@runs@{runId}.yaml
@@ -137,3 +137,4 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/run-object/get-run
+    - https://docs.apify.com/api/v2#/reference/actors/get-run

--- a/openapi/paths/actors/acts@{actorId}@runs@{runId}@abort.yaml
+++ b/openapi/paths/actors/acts@{actorId}@runs@{runId}@abort.yaml
@@ -119,3 +119,4 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/abort-run/abort-run
+    - https://docs.apify.com/api/v2#/reference/actors/abort-run

--- a/openapi/paths/actors/acts@{actorId}@runs@{runId}@metamorph.yaml
+++ b/openapi/paths/actors/acts@{actorId}@runs@{runId}@metamorph.yaml
@@ -158,3 +158,4 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/metamorph-run/metamorph-run
+    - https://docs.apify.com/api/v2#/reference/actors/metamorph-run

--- a/openapi/paths/actors/acts@{actorId}@runs@{runId}@resurrect.yaml
+++ b/openapi/paths/actors/acts@{actorId}@runs@{runId}@resurrect.yaml
@@ -154,3 +154,4 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/resurrect-run/resurrect-run
+    - https://docs.apify.com/api/v2#/reference/actors/resurrect-run

--- a/openapi/paths/actors/acts@{actorId}@versions.yaml
+++ b/openapi/paths/actors/acts@{actorId}@versions.yaml
@@ -55,6 +55,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/version-collection/get-list-of-versions
+    - https://docs.apify.com/api/v2#/reference/actors/get-list-of-versions
   x-py-parent: ActorVersionCollectionClientAsync
   x-py-name: list
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorVersionCollectionClientAsync#list
@@ -130,6 +131,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/version-collection/create-version
+    - https://docs.apify.com/api/v2#/reference/actors/create-version
   x-py-parent: ActorVersionCollectionClientAsync
   x-py-name: create
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorVersionCollectionClientAsync#create

--- a/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}.yaml
+++ b/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}.yaml
@@ -76,6 +76,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/version-object/get-version
+    - https://docs.apify.com/api/v2#/reference/actors/get-version
   x-py-parent: ActorVersionClientAsync
   x-py-name: get
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorVersionClientAsync#get
@@ -190,6 +191,7 @@ put:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/version-object/update-version
+    - https://docs.apify.com/api/v2#/reference/actors/update-version
   x-py-parent: ActorVersionClientAsync
   x-py-name: update
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorVersionClientAsync#update
@@ -275,3 +277,4 @@ delete:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/version-object/delete-version
+    - https://docs.apify.com/api/v2#/reference/actors/delete-version

--- a/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}@env-vars.yaml
+++ b/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}@env-vars.yaml
@@ -35,6 +35,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/environment-variable-collection/get-list-of-environment-variables
+    - https://docs.apify.com/api/v2#/reference/actors/get-list-of-environment-variables
   x-py-parent: ActorEnvVarCollectionClientAsync
   x-py-name: list
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorEnvVarCollectionClientAsync#list
@@ -114,6 +115,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/environment-variable-collection/create-environment-variable
+    - https://docs.apify.com/api/v2#/reference/actors/create-environment-variable
   x-py-parent: ActorEnvVarCollectionClientAsync
   x-py-name: create
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorEnvVarCollectionClientAsync#create

--- a/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}.yaml
+++ b/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}@env-vars@{envVarName}.yaml
@@ -49,6 +49,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/environment-variable-object/get-environment-variable
+    - https://docs.apify.com/api/v2#/reference/actors/get-environment-variable
   x-py-parent: ActorEnvVarClientAsync
   x-py-name: get
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorEnvVarClientAsync#get
@@ -134,6 +135,7 @@ put:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/environment-variable-object/update-environment-variable
+    - https://docs.apify.com/api/v2#/reference/actors/update-environment-variable
   x-py-parent: ActorEnvVarClientAsync
   x-py-name: update
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/ActorEnvVarClientAsync#update
@@ -181,3 +183,4 @@ delete:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/environment-variable-object/delete-environment-variable
+    - https://docs.apify.com/api/v2#/reference/actors/delete-environment-variable

--- a/openapi/paths/actors/acts@{actorId}@webhooks.yaml
+++ b/openapi/paths/actors/acts@{actorId}@webhooks.yaml
@@ -64,3 +64,4 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/actors/webhook-collection/get-list-of-webhooks
+    - https://docs.apify.com/api/v2#/reference/actors/get-list-of-webhooks

--- a/openapi/paths/datasets/datasets.yaml
+++ b/openapi/paths/datasets/datasets.yaml
@@ -90,6 +90,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/datasets/dataset-collection/get-list-of-datasets
+    - https://docs.apify.com/api/v2#/reference/datasets/get-list-of-datasets
   x-js-parent: DatasetCollectionClient
   x-js-name: list
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/DatasetCollectionClient#list
@@ -145,6 +146,10 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/datasets/dataset-collection/create-dataset
+    - https://docs.apify.com/api/v2#/reference/datasets/create-dataset
+    # remove this
+    - https://docs.apify.com/api/v2#/reference/datasets/get-list-of-datasets
+
   x-js-parent: DatasetCollectionClient
   x-js-name: getOrCreate
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/DatasetCollectionClient#getOrCreate

--- a/openapi/paths/datasets/datasets.yaml
+++ b/openapi/paths/datasets/datasets.yaml
@@ -147,8 +147,6 @@ post:
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/datasets/dataset-collection/create-dataset
     - https://docs.apify.com/api/v2#/reference/datasets/create-dataset
-    # remove this
-    - https://docs.apify.com/api/v2#/reference/datasets/get-list-of-datasets
 
   x-js-parent: DatasetCollectionClient
   x-js-name: getOrCreate

--- a/openapi/paths/datasets/datasets@{datasetId}.yaml
+++ b/openapi/paths/datasets/datasets@{datasetId}.yaml
@@ -51,6 +51,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/datasets/dataset/get-dataset
+    - https://docs.apify.com/api/v2#/reference/datasets/get-dataset
   x-js-parent: DatasetClient
   x-js-name: get
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/DatasetClient#get
@@ -107,6 +108,7 @@ put:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/datasets/dataset/update-dataset
+    - https://docs.apify.com/api/v2#/reference/datasets/update-dataset
   x-js-parent: DatasetClient
   x-js-name: update
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/DatasetClient#update
@@ -136,6 +138,7 @@ delete:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/datasets/dataset/delete-dataset
+    - https://docs.apify.com/api/v2#/reference/datasets/delete-dataset
   x-js-parent: DatasetClient
   x-js-name: delete
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/DatasetClient#delete

--- a/openapi/paths/datasets/datasets@{datasetId}@items.yaml
+++ b/openapi/paths/datasets/datasets@{datasetId}@items.yaml
@@ -461,6 +461,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/datasets/item-collection/get-items
+    - https://docs.apify.com/api/v2#/reference/datasets/get-items
   x-js-parent: DatasetClient
   x-js-name: listItems
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/DatasetClient#listItems
@@ -525,6 +526,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/datasets/item-collection/put-items
+    - https://docs.apify.com/api/v2#/reference/datasets/put-items
   x-js-parent: DatasetClient
   x-js-name: pushItems
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/DatasetClient#pushItems

--- a/openapi/paths/key-value-stores/key-value-stores.yaml
+++ b/openapi/paths/key-value-stores/key-value-stores.yaml
@@ -70,6 +70,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/key-value-stores/store-collection/get-list-of-key-value-stores
+    - https://docs.apify.com/api/v2#/reference/key-value-stores/get-list-of-key-value-stores
   x-js-parent: KeyValueStoreCollectionClient
   x-js-name: list
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/KeyValueStoreCollectionClient#list
@@ -128,6 +129,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/key-value-stores/store-collection/create-key-value-store
+    - https://docs.apify.com/api/v2#/reference/key-value-stores/create-key-value-store
   x-js-parent: KeyValueStoreCollectionClient
   x-js-name: getOrCreate
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/KeyValueStoreCollectionClient#getOrCreate

--- a/openapi/paths/key-value-stores/key-value-stores@{storeId}.yaml
+++ b/openapi/paths/key-value-stores/key-value-stores@{storeId}.yaml
@@ -29,6 +29,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/key-value-stores/store-object/get-store
+    - https://docs.apify.com/api/v2#/reference/key-value-stores/get-store
   x-js-parent: KeyValueStoreClient
   x-js-name: get
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/KeyValueStoreClient#get
@@ -75,6 +76,7 @@ put:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/key-value-stores/store-object/update-store
+    - https://docs.apify.com/api/v2#/reference/key-value-stores/update-store
   x-js-parent: KeyValueStoreClient
   x-js-name: update
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/KeyValueStoreClient#update
@@ -104,6 +106,7 @@ delete:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/key-value-stores/store-object/delete-store
+    - https://docs.apify.com/api/v2#/reference/key-value-stores/delete-store
   x-js-parent: KeyValueStoreClient
   x-js-name: delete
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/KeyValueStoreClient#delete

--- a/openapi/paths/key-value-stores/key-value-stores@{storeId}@keys.yaml
+++ b/openapi/paths/key-value-stores/key-value-stores@{storeId}@keys.yaml
@@ -61,6 +61,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/key-value-stores/key-collection/get-list-of-keys
+    - https://docs.apify.com/api/v2#/reference/key-value-stores/get-list-of-keys
   x-js-parent: KeyValueStoreClient
   x-js-name: listKeys
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/KeyValueStoreClient#listKeys

--- a/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
+++ b/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
@@ -62,6 +62,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/key-value-stores/record/get-record
+    - https://docs.apify.com/api/v2#/reference/key-value-stores/get-record
   x-js-parent: KeyValueStoreClient
   x-js-name: recordExists
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/KeyValueStoreClient#recordExists
@@ -145,6 +146,7 @@ put:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/key-value-stores/record/put-record
+    - https://docs.apify.com/api/v2#/reference/key-value-stores/put-record
   x-js-parent: KeyValueStoreClient
   x-js-name: setRecord
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/KeyValueStoreClient#setRecord
@@ -182,6 +184,7 @@ delete:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/key-value-stores/record/delete-record
+    - https://docs.apify.com/api/v2#/reference/key-value-stores/delete-record
   x-js-parent: KeyValueStoreClient
   x-js-name: deleteRecord
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/KeyValueStoreClient#deleteRecord

--- a/openapi/paths/logs/logs@{buildOrRunId}.yaml
+++ b/openapi/paths/logs/logs@{buildOrRunId}.yaml
@@ -4,6 +4,7 @@ get:
   summary: Get log
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/logs/log/get-log
+    - https://docs.apify.com/api/v2#/reference/logs/get-log
   description: ''
   operationId: log_get
   parameters:

--- a/openapi/paths/request-queues/request-queues.yaml
+++ b/openapi/paths/request-queues/request-queues.yaml
@@ -75,6 +75,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/request-queues/queue-collection/get-list-of-request-queues
+    - https://docs.apify.com/api/v2#/reference/request-queues/get-list-of-request-queues
   x-js-parent: RequestQueueCollectionClient
   x-js-name: list
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RequestQueueCollectionClient#list
@@ -149,6 +150,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/request-queues/queue-collection/create-request-queue
+    - https://docs.apify.com/api/v2#/reference/request-queues/create-request-queue
   x-js-parent: RequestQueueCollectionClient
   x-js-name: getOrCreate
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RequestQueueCollectionClient#getOrCreate

--- a/openapi/paths/request-queues/request-queues@{queueId}.yaml
+++ b/openapi/paths/request-queues/request-queues@{queueId}.yaml
@@ -52,6 +52,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/request-queues/queue/get-request-queue
+    - https://docs.apify.com/api/v2#/reference/request-queues/get-request-queue
   x-js-parent: RequestQueueClient
   x-js-name: get
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RequestQueueClient#get
@@ -130,6 +131,7 @@ put:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/request-queues/queue/update-request-queue
+    - https://docs.apify.com/api/v2#/reference/request-queues/update-request-queue
   x-js-parent: RequestQueueClient
   x-js-name: update
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RequestQueueClient#update
@@ -159,6 +161,7 @@ delete:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/request-queues/queue/delete-request-queue
+    - https://docs.apify.com/api/v2#/reference/request-queues/delete-request-queue
   x-js-parent: RequestQueueClient
   x-js-name: delete
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RequestQueueClient#delete

--- a/openapi/paths/request-queues/request-queues@{queueId}@head.yaml
+++ b/openapi/paths/request-queues/request-queues@{queueId}@head.yaml
@@ -102,6 +102,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/request-queues/queue-head/get-head
+    - https://docs.apify.com/api/v2#/reference/request-queues/get-head
   x-js-parent: RequestQueueClient
   x-js-name: listHead
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RequestQueueClient#listHead

--- a/openapi/paths/request-queues/request-queues@{queueId}@head@lock.yaml
+++ b/openapi/paths/request-queues/request-queues@{queueId}@head@lock.yaml
@@ -115,6 +115,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/request-queues/queue-head-with-locks/get-head-and-lock
+    - https://docs.apify.com/api/v2#/reference/request-queues/get-head-and-lock
   x-js-parent: RequestQueueClient
   x-js-name: listAndLockHead
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RequestQueueClient#listAndLockHead

--- a/openapi/paths/request-queues/request-queues@{queueId}@requests.yaml
+++ b/openapi/paths/request-queues/request-queues@{queueId}@requests.yaml
@@ -128,6 +128,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/request-queues/request-collection/list-requests
+    - https://docs.apify.com/api/v2#/reference/request-queues/list-requests
   x-js-parent: RequestQueueClient
   x-js-name: paginateRequests
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RequestQueueClient#paginateRequests
@@ -219,6 +220,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/request-queues/request-collection/add-request
+    - https://docs.apify.com/api/v2#/reference/request-queues/add-request
   x-js-parent: RequestQueueClient
   x-js-name: addRequest
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RequestQueueClient#addRequest

--- a/openapi/paths/request-queues/request-queues@{queueId}@requests@batch.yaml
+++ b/openapi/paths/request-queues/request-queues@{queueId}@requests@batch.yaml
@@ -104,6 +104,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/request-queues/batch-request-operations/add-requests
+    - https://docs.apify.com/api/v2#/reference/request-queues/add-requests
   x-js-parent: RequestQueueClient
   x-js-name: batchAddRequests
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RequestQueueClient#batchAddRequests
@@ -189,6 +190,7 @@ delete:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/request-queues/batch-request-operations/delete-requests
+    - https://docs.apify.com/api/v2#/reference/request-queues/delete-requests
   x-js-parent: RequestQueueClient
   x-js-name: batchDeleteRequests
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RequestQueueClient#batchDeleteRequests

--- a/openapi/paths/request-queues/request-queues@{queueId}@requests@{requestId}.yaml
+++ b/openapi/paths/request-queues/request-queues@{queueId}@requests@{requestId}.yaml
@@ -68,6 +68,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/request-queues/queue/get-request
+    - https://docs.apify.com/api/v2#/reference/request-queues/get-request
   x-js-parent: RequestQueueClient
   x-js-name: get
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RequestQueueClient#get
@@ -188,6 +189,7 @@ put:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/request-queues/queue/update-request
+    - https://docs.apify.com/api/v2#/reference/request-queues/update-request
   x-js-parent: RequestQueueClient
   x-js-name: update
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RequestQueueClient#update
@@ -241,6 +243,7 @@ delete:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/request-queues/queue/delete-request
+    - https://docs.apify.com/api/v2#/reference/request-queues/delete-request
   x-js-parent: RequestQueueClient
   x-js-name: delete
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RequestQueueClient#delete

--- a/openapi/paths/request-queues/request-queues@{queueId}@requests@{requestId}@lock.yaml
+++ b/openapi/paths/request-queues/request-queues@{queueId}@requests@{requestId}@lock.yaml
@@ -75,6 +75,7 @@ put:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/request-queues/request-lock/prolong-request-lock
+    - https://docs.apify.com/api/v2#/reference/request-queues/prolong-request-lock
   x-js-parent: RequestQueueClient
   x-js-name: prolongRequestLock
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RequestQueueClient#prolongRequestLock
@@ -148,6 +149,7 @@ delete:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/request-queues/request-lock/delete-request-lock
+    - https://docs.apify.com/api/v2#/reference/request-queues/delete-request-lock
   x-js-parent: RequestQueueClient
   x-js-name: deleteRequestLock
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/RequestQueueClient#deleteRequestLock

--- a/openapi/paths/schedules/schedules.yaml
+++ b/openapi/paths/schedules/schedules.yaml
@@ -53,6 +53,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/schedules/schedules-collection/get-list-of-schedules
+    - https://docs.apify.com/api/v2#/reference/schedules/get-list-of-schedules
   x-js-parent: ScheduleCollectionClient
   x-js-name: list
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/ScheduleCollectionClient#list
@@ -97,6 +98,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/schedules/schedules-collection/create-schedule
+    - https://docs.apify.com/api/v2#/reference/schedules/create-schedule
   x-js-parent: ScheduleCollectionClient
   x-js-name: create
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/ScheduleCollectionClient#create

--- a/openapi/paths/schedules/schedules@{scheduleId}.yaml
+++ b/openapi/paths/schedules/schedules@{scheduleId}.yaml
@@ -24,6 +24,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/schedules/schedule-object/get-schedule
+    - https://docs.apify.com/api/v2#/reference/schedules/get-schedule
   x-js-parent: ScheduleClient
   x-js-name: get
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/ScheduleClient#get
@@ -76,6 +77,7 @@ put:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/schedules/schedule-object/update-schedule
+    - https://docs.apify.com/api/v2#/reference/schedules/update-schedule
   x-js-parent: ScheduleClient
   x-js-name: update
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/ScheduleClient#update
@@ -110,6 +112,7 @@ delete:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/schedules/schedule-object/delete-schedule
+    - https://docs.apify.com/api/v2#/reference/schedules/delete-schedule
   x-js-parent: ScheduleClient
   x-js-name: delete
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/ScheduleClient#delete

--- a/openapi/paths/schedules/schedules@{scheduleId}@log.yaml
+++ b/openapi/paths/schedules/schedules@{scheduleId}@log.yaml
@@ -36,6 +36,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/schedules/schedule-log/get-schedule-log
+    - https://docs.apify.com/api/v2#/reference/schedules/get-schedule-log
   x-js-parent: ScheduleClient
   x-js-name: getLog
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/ScheduleClient#getLog

--- a/openapi/paths/store/store.yaml
+++ b/openapi/paths/store/store.yaml
@@ -144,3 +144,4 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/store/store-actors-collection/get-list-of-actors-in-store
+    - https://docs.apify.com/api/v2#/reference/store/get-list-of-actors-in-store

--- a/openapi/paths/users/users@me.yaml
+++ b/openapi/paths/users/users@me.yaml
@@ -19,3 +19,4 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/users/private-data/get-private-user-data
+    - https://docs.apify.com/api/v2#/reference/users/get-private-user-data

--- a/openapi/paths/users/users@me@limits.yaml
+++ b/openapi/paths/users/users@me@limits.yaml
@@ -18,6 +18,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/users/account-and-usage-limits/get-limits
+    - https://docs.apify.com/api/v2#/reference/users/get-limits
 put:
   tags:
     - Users/Account and usage limits
@@ -37,7 +38,10 @@ put:
       description: ''
       headers: {}
       content:
-          application/json:
-            schema:
-              type: object
+        application/json:
+          schema:
+            type: object
   deprecated: false
+  x-legacy-doc-urls:
+    - https://docs.apify.com/api/v2#/reference/users/account-and-usage-limits/update-limits
+    - https://docs.apify.com/api/v2#/reference/users/update-limits

--- a/openapi/paths/users/users@me@usage@monthly.yaml
+++ b/openapi/paths/users/users@me@usage@monthly.yaml
@@ -31,3 +31,4 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/users/monthly-usage/get-monthly-usage
+    - https://docs.apify.com/api/v2#/reference/users/get-monthly-usage

--- a/openapi/paths/users/users@{userId}.yaml
+++ b/openapi/paths/users/users@{userId}.yaml
@@ -28,3 +28,4 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/users/public-data/get-public-user-data
+    - https://docs.apify.com/api/v2#/reference/users/get-public-user-data

--- a/openapi/paths/webhook-dispatches/webhook-dispatches.yaml
+++ b/openapi/paths/webhook-dispatches/webhook-dispatches.yaml
@@ -58,6 +58,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/webhook-dispatches/webhook-dispatches-collection/get-list-of-webhook-dispatches
+    - https://docs.apify.com/api/v2#/reference/webhook-dispatches/get-list-of-webhook-dispatches
   x-js-parent: WebhookDispatchCollectionClient
   x-js-name: list
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/WebhookDispatchCollectionClient#list

--- a/openapi/paths/webhook-dispatches/webhook-dispatches@{dispatchId}.yaml
+++ b/openapi/paths/webhook-dispatches/webhook-dispatches@{dispatchId}.yaml
@@ -24,6 +24,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/webhook-dispatches/webhook-dispatch-object/get-webhook-dispatch
+    - https://docs.apify.com/api/v2#/reference/webhook-dispatches/get-webhook-dispatch
   x-js-parent: WebhookDispatchClient
   x-js-name: get
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/WebhookDispatchClient#get

--- a/openapi/paths/webhooks/webhooks.yaml
+++ b/openapi/paths/webhooks/webhooks.yaml
@@ -58,6 +58,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/webhooks/webhook-collection/get-list-of-webhooks
+    - https://docs.apify.com/api/v2#/reference/webhooks/get-list-of-webhooks
   x-js-parent: WebhookCollectionClient
   x-js-name: list
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/WebhookCollectionClient#list
@@ -186,6 +187,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/webhooks/webhook-collection/create-webhook
+    - https://docs.apify.com/api/v2#/reference/webhooks/create-webhook
   x-js-parent: WebhookCollectionClient
   x-js-name: create
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/WebhookCollectionClient#create

--- a/openapi/paths/webhooks/webhooks@{webhookId}.yaml
+++ b/openapi/paths/webhooks/webhooks@{webhookId}.yaml
@@ -24,6 +24,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/webhooks/webhook-object/get-webhook
+    - https://docs.apify.com/api/v2#/reference/webhooks/get-webhook
   x-js-parent: WebhookClient
   x-js-name: get
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/WebhookClient#get
@@ -82,6 +83,7 @@ put:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/webhooks/webhook-object/update-webhook
+    - https://docs.apify.com/api/v2#/reference/webhooks/update-webhook
   x-js-parent: WebhookClient
   x-js-name: update
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/WebhookClient#update
@@ -115,6 +117,7 @@ delete:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/webhooks/webhook-object/delete-webhook
+    - https://docs.apify.com/api/v2#/reference/webhooks/delete-webhook
   x-js-parent: WebhookClient
   x-js-name: delete
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/WebhookClient#delete

--- a/openapi/paths/webhooks/webhooks@{webhookId}@dispatches.yaml
+++ b/openapi/paths/webhooks/webhooks@{webhookId}@dispatches.yaml
@@ -24,6 +24,7 @@ get:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/webhooks/dispatches-collection/get-collection
+    - https://docs.apify.com/api/v2#/reference/webhooks/get-collection
   x-py-parent: WebhookClientAsync
   x-py-name: dispatches
   x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/WebhookClientAsync#dispatches

--- a/openapi/paths/webhooks/webhooks@{webhookId}@test.yaml
+++ b/openapi/paths/webhooks/webhooks@{webhookId}@test.yaml
@@ -24,6 +24,7 @@ post:
   deprecated: false
   x-legacy-doc-urls:
     - https://docs.apify.com/api/v2#/reference/webhooks/webhook-test/test-webhook
+    - https://docs.apify.com/api/v2#/reference/webhooks/test-webhook
   x-js-parent: WebhookClient
   x-js-name: test
   x-js-doc-url: https://docs.apify.com/api/client/js/reference/class/WebhookClient#test


### PR DESCRIPTION
From the conversation with @jirispilka:

On the datasets [documentation page](https://docs.apify.com/platform/storage/dataset), there’s a sentence :“To retrieve a list of your datasets, send a GET request to the [Get list of datasets](https://docs.apify.com/api/v2#/reference/datasets/get-list-of-datasets) endpoint.” 

Bad behavior:
This link takes you to the top of the API docs rather than the specified resource. 

Expected behavior:
The page loads and scrolls to the [Get List of Datasets](https://docs.apify.com/api/v2#tag/DatasetsDataset-collection/operation/datasets_get)

[Reference to the private slack](https://apify.slack.com/archives/C010Q0FBYG3/p1731398912774059)