### PR TITLE
Fix: broken link from the old docs

### DIFF
--- a/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
+++ b/openapi/paths/key-value-stores/key-value-stores@{storeId}@records@{recordKey}.yaml
@@ -6,7 +6,7 @@ get:
     Gets a value stored in the key-value store under a specific key.
 
     The response body has the same `Content-Encoding` header as it was set in
-    [Put record](#/reference/key-value-stores/key-collection/put-record).
+    [Put record](#tag/Key-value-storesRecord/operation/keyValueStore_record_put).
 
     If the request does not define the `Accept-Encoding` HTTP header with the
     right encoding, the record will be decompressed.


### PR DESCRIPTION
Fixing broken link reported by @jirispilka. It has never worked, even in the [old documentation](https://docs.apify.com/api/v2-old#/reference/key-value-stores/key-collection).