### PR TITLE
chore: Add info about omitted user fields

### DIFF
--- a/openapi/paths/users/users@me.yaml
+++ b/openapi/paths/users/users@me.yaml
@@ -7,6 +7,8 @@ get:
     and private information.
 
     The user account is identified by the provided authentication token.
+
+    The fields `plan`, `email` and `profile` are omitted when this endpoint is accessed from Actor run.
   operationId: users_me_get
   responses:
     '200':


### PR DESCRIPTION
We remove these fields when the endpoint is accessed from the actor run. This is done to avoid leaking sensitive fields to public actors. It's not mentioned anywhere.