### PR TITLE
fix: fix use of HTML in the descriptions to support MDX

### DIFF
--- a/.redocly.yaml
+++ b/.redocly.yaml
@@ -15,8 +15,8 @@ theme:
     expandDefaultResponse: true
     expandDefaultRequest: true
     expandResponses: all
-    schemaExpansionLevel: 2
-    jsonSampleExpandLevel: 2
+    schemasExpansionLevel: 2
+    jsonSamplesExpandLevel: 2
 
   colors:
     primary:

--- a/openapi/components/tags.yaml
+++ b/openapi/components/tags.yaml
@@ -63,12 +63,14 @@
         <td>
             Source code is comprised of multiple files specified in the <code>sourceFiles</code>
     array.
-            Each item of the array is an object with the following fields:<br>
-            <code>name</code></li> - File path and name<br>
-            <code>format</code></li> - Format of the content, can be either <code>"TEXT"</code>
-    or <code>"BASE64"</code><br>
-            <code>content</code></li> - File content<br>
-            <br>
+            Each item of the array is an object with the following fields:<br />
+            <ul>
+            <li><code>name</code></li> - File path and name<br />
+            <li><code>format</code></li> - Format of the content, can be either <code>"TEXT"</code>
+    or <code>"BASE64"</code><br />
+            <li><code>content</code></li> - File content<br />
+            </ul>
+            <br />
             Source files can be shown and edited in the Apify Console's Web IDE.
         </td>
       </tr>

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -3,41 +3,33 @@ info:
   title: Apify API
   description: >-
 
-    <blockquote>
-      <strong>UPDATE 2024-07-09:</strong>
-      We have rolled out this new Apify API Documentation. In case of any issues, please <a href="https://github.com/apify/openapi/issues">report here</a>.
-      The old API Documentation is still <a href="https://docs.apify.com/api/v2-old">available here</a>.
-    </blockquote>
-
+    > **UPDATE 2024-07-09:**
+    > We have rolled out this new Apify API Documentation. In case of any issues, please [report here](https://github.com/apify/openapi/issues).
+    > The old API Documentation is still [available here](https://docs.apify.com/api/v2-old).
 
     The Apify API (version 2) provides programmatic access to the [Apify
     platform](https://docs.apify.com).
 
     The API is organized around
     [RESTful](https://en.wikipedia.org/wiki/Representational_state_transfer)
-
     HTTP endpoints.
 
     All requests and responses (including errors) are encoded in
     [JSON](http://www.json.org/) format with UTF-8 encoding,
-
     with a few exceptions that are explicitly described in the reference.
 
 
     To access the API using [Node.js](https://nodejs.org/en/), we recommend the
-
     [`apify-client`](https://docs.apify.com/api/client/js) [NPM
     package](https://www.npmjs.com/package/apify-client).
 
     To access the API using [Python](https://www.python.org/), we recommend the
-
     [`apify-client`](https://docs.apify.com/api/client/python) [PyPI
     package](https://pypi.org/project/apify-client/).
 
     The clients' functions correspond to the API endpoints and have the same
     parameters. This simplifies development of apps that depend on the Apify
     platform.
-
 
     **Note:** All requests with JSON payloads need to specify the `Content-Type:
     application/json` HTTP header!
@@ -262,7 +254,8 @@ info:
       </tr>
       <tr>
         <td><code>desc</code></td>
-        <td>By default, items are sorted in the order in which they were created or added to the list.
+        <td>
+        By default, items are sorted in the order in which they were created or added to the list.
         This feature is useful when fetching all the items, because it ensures that items
         created after the client started the pagination will not be skipped.
         If you specify the <code>desc=1</code> parameter, the items will be returned in the reverse order,

--- a/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}.yaml
+++ b/openapi/paths/actors/acts@{actorId}@versions@{versionNumber}.yaml
@@ -14,11 +14,13 @@ get:
         <td><code>"SOURCE_FILES"</code></td>
         <td>
             Source code is comprised of multiple files specified in the <code>sourceFiles</code> array.
-            Each item of the array is an object with the following fields:<br>
-            <code>name</code></li> - File path and name<br>
-            <code>format</code></li> - Format of the content, can be either <code>"TEXT"</code> or <code>"BASE64"</code><br>
-            <code>content</code></li> - File content<br>
-            <br>
+            Each item of the array is an object with the following fields:<br />
+            <ul>
+            <li><code>name</code></li> - File path and name<br />
+            <li><code>format</code></li> - Format of the content, can be either <code>"TEXT"</code> or <code>"BASE64"</code><br />
+            <li><code>content</code></li> - File content<br />
+            </ul>
+            <br />
             Source files can be shown and edited in the Apify Console's Web IDE.
         </td>
       </tr>
@@ -96,11 +98,13 @@ put:
         <td><code>"SOURCE_FILES"</code></td>
         <td>
             Source code is comprised of multiple files specified in the <code>sourceFiles</code> array.
-            Each item of the array is an object with the following fields:<br>
-            <code>name</code></li> - File path and name<br>
-            <code>format</code></li> - Format of the content, can be either <code>"TEXT"</code> or <code>"BASE64"</code><br>
-            <code>content</code></li> - File content<br>
-            <br>
+            Each item of the array is an object with the following fields:<br />
+            <ul>
+            <li><code>name</code></li> - File path and name<br />
+            <li><code>format</code></li> - Format of the content, can be either <code>"TEXT"</code> or <code>"BASE64"</code><br />
+            <li><code>content</code></li> - File content<br />
+            </ul>
+            <br />
             Source files can be shown and edited in the Apify Console's Web IDE.
         </td>
       </tr>
@@ -214,11 +218,13 @@ delete:
         <td><code>"SOURCE_FILES"</code></td>
         <td>
             Source code is comprised of multiple files specified in the <code>sourceFiles</code> array.
-            Each item of the array is an object with the following fields:<br>
-            <code>name</code></li> - File path and name<br>
-            <code>format</code></li> - Format of the content, can be either <code>"TEXT"</code> or <code>"BASE64"</code><br>
-            <code>content</code></li> - File content<br>
-            <br>
+            Each item of the array is an object with the following fields:<br />
+            <ul>
+            <li><code>name</code></li> - File path and name<br />
+            <li><code>format</code></li> - Format of the content, can be either <code>"TEXT"</code> or <code>"BASE64"</code><br />
+            <li><code>content</code></li> - File content<br />
+            </ul>
+            <br />
             Source files can be shown and edited in the Apify Console's Web IDE.
         </td>
       </tr>

--- a/plugins/decorators/client-references-links-decorator.js
+++ b/plugins/decorators/client-references-links-decorator.js
@@ -5,7 +5,7 @@ const X_JS_DOC_URLS_PROPERTY = "x-js-doc-url";
 /**
  * This decorator adds links to the Apify API Client libraries Python and JS references.
  *
- * The Apify API OpenAPI specfication has been enriched with Apify specifc vendor extensions 
+ * The Apify API OpenAPI specification has been enriched with Apify specific vendor extensions
  * on `operation` and `tag` level to link the Apify Client functionality e.g. for `actorBuild_get`:
  * ```
  * x-js-parent: BuildClient
@@ -15,7 +15,7 @@ const X_JS_DOC_URLS_PROPERTY = "x-js-doc-url";
  * x-py-name: get
  * x-py-doc-url: https://docs.apify.com/api/client/python/reference/class/BuildClientAsync#get
  * ```
- * 
+ *
  * The prepended HTML example:
  * ```
  * <span style="float: right;">
@@ -35,27 +35,27 @@ const X_JS_DOC_URLS_PROPERTY = "x-js-doc-url";
 function ClientReferencesLinksDecorator(target) {
     const pyLink = target[X_PY_DOC_URLS_PROPERTY];
     const jsLink = target[X_JS_DOC_URLS_PROPERTY];
- 
-    const jsImgUrl = "https://raw.githubusercontent.com/apify/openapi/b1206ac2adf8f39b05e5a09bf32c2802af58d851/assets/javascript.svg";    
+
+    const jsImgUrl = "https://raw.githubusercontent.com/apify/openapi/b1206ac2adf8f39b05e5a09bf32c2802af58d851/assets/javascript.svg";
     const pyImgUrl = "https://raw.githubusercontent.com/apify/openapi/b1206ac2adf8f39b05e5a09bf32c2802af58d851/assets/python.svg";
 
     const jsAlt = "Apify API JavaScript Client Reference";
     const pyAlt = "Apify API Python Client Reference";
 
-    // Purposedly using `span` element here instead of `div`
+    // Purposely using `span` element here instead of `div`
     // Due to how redoc works, when `div` used, the markdown rendering in of `description` ceased to work.
-    let prepend = `<span style="display: block; float: right; padding-left: 6px;">`;
-    
+    let prepend = `<span class="openapi-clients-box">`;
+
     if (pyLink || jsLink) {
-        prepend += `<span style="display: inline-block; font-family: 'San Francisco', Helvetica, Arial, sans-serif; color: #6C7590;font-style: normal; font-weight: 700; font-size: 14px; line-height: 20px; text-transform: uppercase; padding-bottom: 6px;">Clients</span>`
+        prepend += `<span class="openapi-clients-box-heading">Clients</span>`
     }
 
     if (pyLink) {
-        prepend += `<a href="${pyLink}" target="_blank"><img src="${pyImgUrl}" style="padding-bottom: 6px; display: block;" alt="${pyAlt}"/></a>`;
+        prepend += `<a href="${pyLink}" target="_blank"><img src="${pyImgUrl}" class="openapi-clients-box-icon" alt="${pyAlt}"/></a>`;
     }
 
     if (jsLink) {
-        prepend += `<a href="${jsLink}" target="_blank"><img src="${jsImgUrl}" style="padding-bottom: 6px; display: block;" alt="${jsAlt}" /></a>`;
+        prepend += `<a href="${jsLink}" target="_blank"><img src="${jsImgUrl}" class="openapi-clients-box-icon" alt="${jsAlt}" /></a>`;
     }
 
     prepend += `</span>`;


### PR DESCRIPTION
During integration of our openapi specs to the new docusaurus plugin, I faced several problems with our invalid HTML descriptions. This PR fixes them:

- missing `<ul>` and `<li>`
- use `<br />` instead of `<br>`
- use markdown instead of HTML for `<blockquote>`

Also removes the inline `style` tags in favor of classes, since that approach was also incompatible with MDX.

To be merged after those styles are deployed in the apify-docs repo.