### PR TITLE
fix: request queue creation doesn't require `name`

### DIFF
--- a/openapi/components/schemas/request-queues/RequestQueue.yaml
+++ b/openapi/components/schemas/request-queues/RequestQueue.yaml
@@ -1,7 +1,6 @@
 title: RequestQueue
 required:
   - id
-  - name
   - userId
   - createdAt
   - modifiedAt

--- a/openapi/paths/request-queues/request-queues.yaml
+++ b/openapi/paths/request-queues/request-queues.yaml
@@ -102,7 +102,7 @@ post:
     - name: name
       in: query
       description: Custom unique name to easily identify the queue in the future.
-      required: true
+      required: false
       style: form
       explode: true
       schema:


### PR DESCRIPTION
The request queue creation endpoint (`POST v2/request-queues`) doesn't require the `name` query parameter. This creates an unnamed RQ which gets automatically deleted after 7 days. 

This applies to the response as well - the API doesn't include a `name` for the unnamed RQs.

![obrazek](https://github.com/user-attachments/assets/89c4fd01-ae95-4c74-8563-1ae4dc18e540)