### PR TITLE
feat: Introducing actorDefinition prop for actor build, and deprecating inputSchema and readme

### DIFF
--- a/openapi/components/schemas/actor-builds/Build.yaml
+++ b/openapi/components/schemas/actor-builds/Build.yaml
@@ -103,5 +103,39 @@ example:
   inputSchema: '{\n  \"title\": \"Schema for ... }'
   readme: '# Magic Actor\nThis Actor is magic.'
   buildNumber: 0.1.1
-  actorDefinition: null
+  actorDefinition:
+      actorSpecification: 1
+      name: "exmpla-actor"
+      version: "1.0"
+      buildTag: "latest"
+      environmentVariables:
+          DEBUG_MODE: "false"
+      input:
+          type: "object"
+          properties:
+              prompt:
+                  type: "string"
+                  description: "The text prompt to generate completions for."
+              maxTokens:
+                  type: "integer"
+                  description: "The maximum number of tokens to generate."
+          required:
+              - prompt
+      storages:
+          dataset:
+              type: "object"
+              $schema: "http://json-schema.org/draft-07/schema#"
+              properties:
+                  id:
+                      type: "string"
+                      description: "Unique identifier for the generated text."
+                  text:
+                      type: "string"
+                      description: "The generated text output from the model."
+              required:
+                  - id
+                  - text
+      minMemoryMbytes: 512
+      maxMemoryMbytes: 2048
+      usesStandbyMode: false
 

--- a/openapi/components/schemas/actor-builds/Build.yaml
+++ b/openapi/components/schemas/actor-builds/Build.yaml
@@ -61,14 +61,20 @@ properties:
   inputSchema:
     type: string
     nullable: true
+    deprecated: true # Marked as deprecated in favor of actorDefinition.
     example: '{\n  \"title\": \"Schema for ... }'
   readme:
     type: string
     nullable: true
+    deprecated: true # Marked as deprecated in favor of actorDefinition.
     example: '# Magic Actor\nThis Actor is magic.'
   buildNumber:
     type: string
     example: 0.1.1
+  actorDefinition:
+      oneOf:
+        - $ref: "../actors/ActorDefinition.yaml"
+        - type: "null"
 example:
   id: HG7ML7M8z78YcAPEB
   actId: janedoe~my-actor
@@ -97,3 +103,5 @@ example:
   inputSchema: '{\n  \"title\": \"Schema for ... }'
   readme: '# Magic Actor\nThis Actor is magic.'
   buildNumber: 0.1.1
+  actorDefinition: null
+

--- a/openapi/components/schemas/actors/ActorDefinition.yaml
+++ b/openapi/components/schemas/actors/ActorDefinition.yaml
@@ -1,58 +1,58 @@
 title: ActorDefinition
-description: "The main configuration of the Actor, the full specification can be found in [Apify docs](https://docs.apify.com/platform/actors/development/actor-definition/actor-json)"
+description: The main configuration of the Actor, the full specification can be found in [Apify docs](https://docs.apify.com/platform/actors/development/actor-definition/actor-json)
 type: object
 properties:
     actorSpecification:
-        type: "integer"
+        type: integer
         enum: [1]
-        description: "The version of the Actor specification. This property must be set to 1."
+        description: The version of the Actor specification. This property must be set to 1.
     name:
-        type: "string"
-        description: "The name of the Actor."
+        type: string
+        description: The name of the Actor.
     version:
-        type: "string"
-        pattern: "^[0-9]+\\.[0-9]+$"
-        description: "The version of the Actor, specified in the format [Number].[Number], e.g., 0.1, 1.0."
+        type: string
+        pattern: ^[0-9]+\\.[0-9]+$
+        description: The version of the Actor, specified in the format [Number].[Number], e.g., 0.1, 1.0.
     buildTag:
-        type: "string"
-        description: "The tag name to be applied to a successful build of the Actor. Defaults to 'latest' if not specified."
+        type: string
+        description: The tag name to be applied to a successful build of the Actor. Defaults to 'latest' if not specified.
     environmentVariables:
-        type: "object"
+        type: object
         additionalProperties:
-            type: "string"
-        description: "A map of environment variables to be used during local development and deployment."
+            type: string
+        description: A map of environment variables to be used during local development and deployment.
     dockerfile:
-        type: "string"
-        description: "The path to the Dockerfile used for building the Actor on the platform."
+        type: string
+        description: The path to the Dockerfile used for building the Actor on the platform.
     dockerContextDir:
-        type: "string"
-        description: "The path to the directory used as the Docker context when building the Actor."
+        type: string
+        description: The path to the directory used as the Docker context when building the Actor.
     readme:
-        type: "string"
-        description: "The path to the README file for the Actor."
+        type: string
+        description: The path to the README file for the Actor.
     input:
-        type: "object"
-        description: "The input schema object, the full specification can be found in [Apify docs](https://docs.apify.com/platform/actors/development/actor-definition/input-schema)"
+        type: object
+        description: The input schema object, the full specification can be found in [Apify docs](https://docs.apify.com/platform/actors/development/actor-definition/input-schema)
     changelog:
-        type: "string"
-        description: "The path to the CHANGELOG file displayed in the Actor's information tab."
+        type: string
+        description: The path to the CHANGELOG file displayed in the Actor's information tab.
     storages:
         type: object
         properties:
             dataset:
-                type: "object"
-                description: "Defines the schema of items in your dataset, the full specification can be found in [Apify docs](https://docs.apify.com/platform/actors/development/actor-definition/dataset-schema)"
+                type: object
+                description: Defines the schema of items in your dataset, the full specification can be found in [Apify docs](https://docs.apify.com/platform/actors/development/actor-definition/dataset-schema)
     minMemoryMbytes:
-        type: "integer"
+        type: integer
         minimum: 256
-        description: "Specifies the minimum amount of memory in megabytes required by the Actor."
+        description: Specifies the minimum amount of memory in megabytes required by the Actor.
     maxMemoryMbytes:
-        type: "integer"
+        type: integer
         minimum: 256
-        description: "Specifies the maximum amount of memory in megabytes required by the Actor."
+        description: Specifies the maximum amount of memory in megabytes required by the Actor.
     usesStandbyMode:
-        type: "boolean"
-        description: "Specifies whether the Actor will have Standby mode enabled."
+        type: boolean
+        description: Specifies whether the Actor will have Standby mode enabled.
 required:
     - actorSpecification
     - name

--- a/openapi/components/schemas/actors/ActorDefinition.yaml
+++ b/openapi/components/schemas/actors/ActorDefinition.yaml
@@ -1,0 +1,59 @@
+title: ActorDefinition
+description: "The main configuration of the Actor, the full specification can be found in [Apify docs](https://docs.apify.com/platform/actors/development/actor-definition/actor-json)"
+type: object
+properties:
+    actorSpecification:
+        type: "integer"
+        enum: [1]
+        description: "The version of the Actor specification. This property must be set to 1."
+    name:
+        type: "string"
+        description: "The name of the Actor."
+    version:
+        type: "string"
+        pattern: "^[0-9]+\\.[0-9]+$"
+        description: "The version of the Actor, specified in the format [Number].[Number], e.g., 0.1, 1.0."
+    buildTag:
+        type: "string"
+        description: "The tag name to be applied to a successful build of the Actor. Defaults to 'latest' if not specified."
+    environmentVariables:
+        type: "object"
+        additionalProperties:
+            type: "string"
+        description: "A map of environment variables to be used during local development and deployment."
+    dockerfile:
+        type: "string"
+        description: "The path to the Dockerfile used for building the Actor on the platform."
+    dockerContextDir:
+        type: "string"
+        description: "The path to the directory used as the Docker context when building the Actor."
+    readme:
+        type: "string"
+        description: "The path to the README file for the Actor."
+    input:
+        type: "object"
+        description: "The input schema object, the full specification can be found in [Apify docs](https://docs.apify.com/platform/actors/development/actor-definition/input-schema)"
+    changelog:
+        type: "string"
+        description: "The path to the CHANGELOG file displayed in the Actor's information tab."
+    storages:
+        type: object
+        properties:
+            dataset:
+                type: "object"
+                description: "Defines the schema of items in your dataset, the full specification can be found in [Apify docs](https://docs.apify.com/platform/actors/development/actor-definition/dataset-schema)"
+    minMemoryMbytes:
+        type: "integer"
+        minimum: 256
+        description: "Specifies the minimum amount of memory in megabytes required by the Actor."
+    maxMemoryMbytes:
+        type: "integer"
+        minimum: 256
+        description: "Specifies the maximum amount of memory in megabytes required by the Actor."
+    usesStandbyMode:
+        type: "boolean"
+        description: "Specifies whether the Actor will have Standby mode enabled."
+required:
+    - actorSpecification
+    - name
+    - version

--- a/openapi/components/schemas/actors/ActorDefinition.yaml
+++ b/openapi/components/schemas/actors/ActorDefinition.yaml
@@ -1,11 +1,11 @@
 title: ActorDefinition
-description: The main configuration of the Actor, the full specification can be found in [Apify docs](https://docs.apify.com/platform/actors/development/actor-definition/actor-json)
+description: The definition of the Actor, the full specification of this field can be found in [Apify docs](https://docs.apify.com/platform/actors/development/actor-definition/actor-json)
 type: object
 properties:
     actorSpecification:
         type: integer
         enum: [1]
-        description: The version of the Actor specification. This property must be set to 1.
+        description: The Actor specification version that this Actor follows. This property must be set to 1.
     name:
         type: string
         description: The name of the Actor.


### PR DESCRIPTION
The actor.json was missing in API, so we recently added it into Apify API by https://github.com/apify/apify-core/pull/18059

In this PR we are updating docs to correspond with these API changes:
- add `actorDefinition` props into Actor build detail API
- deprecate `inputSchema` and `readme` in favor of `actorDefinition`

There are a few new fields which were missing in API currently and will be public after these changes, I would mention:
- `actorDefinition.storages.dataset` - dataset schema
- `actorDefinition.changelog `- markdown of changelog