### PR TITLE
Converting the main description Yaml Block Literal to support proper Markdown

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Apify API
-  description: >-
+  description: |
 
     <blockquote>
       <strong>UPDATE 2024-07-09:</strong>
@@ -9,247 +9,119 @@ info:
       The old API Documentation is still <a href="https://docs.apify.com/api/v2-old">available here</a>.
     </blockquote>
 
-
-    The Apify API (version 2) provides programmatic access to the [Apify
-    platform](https://docs.apify.com).
-
-    The API is organized around
-    [RESTful](https://en.wikipedia.org/wiki/Representational_state_transfer)
-
+    The Apify API (version 2) provides programmatic access to the [Apify platform](https://docs.apify.com).
+    The API is organized around [RESTful](https://en.wikipedia.org/wiki/Representational_state_transfer)
     HTTP endpoints.
-
-    All requests and responses (including errors) are encoded in
-    [JSON](http://www.json.org/) format with UTF-8 encoding,
-
+    All requests and responses (including errors) are encoded in [JSON](http://www.json.org/) format with UTF-8 encoding,
     with a few exceptions that are explicitly described in the reference.
 
-
     To access the API using [Node.js](https://nodejs.org/en/), we recommend the
-
-    [`apify-client`](https://docs.apify.com/api/client/js) [NPM
-    package](https://www.npmjs.com/package/apify-client).
-
+    [`apify-client`](https://docs.apify.com/api/client/js) [NPM package](https://www.npmjs.com/package/apify-client).
     To access the API using [Python](https://www.python.org/), we recommend the
+    [`apify-client`](https://docs.apify.com/api/client/python) [PyPI package](https://pypi.org/project/apify-client/).
+    The clients' functions correspond to the API endpoints and have the same parameters. This simplifies development of apps that depend on the Apify platform.
 
-    [`apify-client`](https://docs.apify.com/api/client/python) [PyPI
-    package](https://pypi.org/project/apify-client/).
-
-    The clients' functions correspond to the API endpoints and have the same
-    parameters. This simplifies development of apps that depend on the Apify
-    platform.
-
-
-    **Note:** All requests with JSON payloads need to specify the `Content-Type:
-    application/json` HTTP header!
-
-    All API endpoints support the `method` query parameter that can override the
-    HTTP method.
-
+    **Note:** All requests with JSON payloads need to specify the `Content-Type: application/json` HTTP header!
+    All API endpoints support the `method` query parameter that can override the HTTP method.
     For example, if you want to call a POST endpoint using a GET request, simply
-
     add the query parameter `method=POST` to the URL and send the GET request.
-
     This feature is especially useful if you want to call Apify API endpoints
-
     from services that can only send GET requests.
 
-
     ## Authentication
-
     <span id="/introduction/authentication"></span>
-
     You can find your API token on the
-
-    [Integrations](https://console.apify.com/account#/integrations) page in the
-    Apify Console.
-
+    [Integrations](https://console.apify.com/account#/integrations) page in the Apify Console.
 
     To use your token in a request, either:
 
-
-    - Add the token to your request's `Authorization` header as `Bearer
-    <token>`.
-
+    - Add the token to your request's `Authorization` header as `Bearer <token>`.
     E.g., `Authorization: Bearer xxxxxxx`.
-
-    [More
-    info](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization).
-    (Recommended).
-
+    [More info](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization). (Recommended).
 
     - Add it as the `token` parameter to your request URL. (Less secure).
 
-
-    Using your token in the request header is more secure than using it as a URL
-    parameter because URLs are often stored
-
-    in browser history and server logs. This creates a chance for someone
-    unauthorized to access
-
+    Using your token in the request header is more secure than using it as a URL parameter because URLs are often stored
+    in browser history and server logs. This creates a chance for someone unauthorized to access
     your API token.
-
 
     **Do not share your API token or password with untrusted parties.**
 
-
-    For more information, see our
-    [integrations](https://docs.apify.com/platform/integrations) documentation.
-
+    For more information, see our [integrations](https://docs.apify.com/platform/integrations) documentation.
 
     ## Basic usage
-
     <span id="/introduction/basic-usage"></span>
-
-    To run an actor, send a POST request to the [Run
-    actor](#/reference/actors/run-collection/run-actor) endpoint using either the
-    actor ID code (e.g. `vKg4IjxZbEYTYeW8T`) or its name (e.g.
-    `janedoe~my-actor`):
-
+    To run an actor, send a POST request to the [Run actor](#/reference/actors/run-collection/run-actor) endpoint using either the actor ID code (e.g. `vKg4IjxZbEYTYeW8T`) or its name (e.g. `janedoe~my-actor`):
 
     `https://api.apify.com/v2/acts/[actor_id]/runs`
 
-
     If the actor is not runnable anonymously, you will receive a 401 or 403
-
     [response code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status).
+    This means you need to add your [secret API token](https://console.apify.com/account#/integrations) to the request's `Authorization` header ([recommended](#/introduction/authentication)) or as a URL query parameter `?token=[your_token]` (less secure).
 
-    This means you need to add your [secret API
-    token](https://console.apify.com/account#/integrations) to the request's
-    `Authorization` header ([recommended](#/introduction/authentication)) or as a
-    URL query parameter `?token=[your_token]` (less secure).
+    Optionally, you can include the query parameters described in the [Run actor](#/reference/actors/run-collection/run-actor) section to customize your run.
 
-
-    Optionally, you can include the query parameters described in the [Run
-    actor](#/reference/actors/run-collection/run-actor) section to customize your
-    run.
-
-
-    If you're using Node.js, the best way to run an actor is using the
-    `Apify.call()` method from the [Apify
-    SDK](https://sdk.apify.com/docs/api/apify#apifycallactid-input-options). It
-    runs the actor using the account you are currently logged into (determined
-    by the [secret API token](https://console.apify.com/account#/integrations)).
-    The result is an [actor run
-    object](https://sdk.apify.com/docs/typedefs/actor-run) and its output (if
-    any).
-
+    If you're using Node.js, the best way to run an actor is using the `Apify.call()` method from the [Apify SDK](https://sdk.apify.com/docs/api/apify#apifycallactid-input-options). It runs the actor using the account you are currently logged into (determined by the [secret API token](https://console.apify.com/account#/integrations)). The result is an [actor run object](https://sdk.apify.com/docs/typedefs/actor-run) and its output (if any).
 
     A typical workflow is as follows:
 
+    1. Run an actor or task using the [Run actor](#/reference/actors/run-collection/run-actor) or [Run task](#/reference/actor-tasks/run-collection/run-task) API endpoints.
 
-    1. Run an actor or task using the [Run
-    actor](#/reference/actors/run-collection/run-actor) or [Run
-    task](#/reference/actor-tasks/run-collection/run-task) API endpoints.
+    2. Monitor the actor run by periodically polling its progress using the [Get run](#/reference/actor-runs/run-object-and-its-storages/get-run) API endpoint.
 
+    3. Fetch the results from the [Get items](#/reference/datasets/item-collection/get-items) API endpoint using the `defaultDatasetId`, which you receive in the Run request response. Additional data may be stored in a key-value store. You can fetch them from the [Get record](#/reference/key-value-stores/record/get-record) API endpoint using the `defaultKeyValueStoreId` and the store's `key`.
 
-    2. Monitor the actor run by periodically polling its progress using the [Get
-    run](#/reference/actor-runs/run-object-and-its-storages/get-run) API
-    endpoint.
-
-
-    3. Fetch the results from the [Get
-    items](#/reference/datasets/item-collection/get-items) API endpoint using the
-    `defaultDatasetId`, which you receive in the Run request response.
-    Additional data may be stored in a key-value store. You can fetch them from
-    the [Get record](#/reference/key-value-stores/record/get-record) API endpoint
-    using the `defaultKeyValueStoreId` and the store's `key`.
-
-
-    **Note**: Instead of periodic polling, you can also run your
-    [actor](#/reference/actors/run-actor-synchronously) or
-    [task](#/reference/actor-tasks/runs-collection/run-task-synchronously)
-    synchronously. This will ensure that the request waits for 300 seconds (5
-    minutes) for the run to finish and returns its output. If the run takes
-    longer, the request will time out and throw an error.
-
+    **Note**: Instead of periodic polling, you can also run your [actor](#/reference/actors/run-actor-synchronously) or [task](#/reference/actor-tasks/runs-collection/run-task-synchronously) synchronously. This will ensure that the request waits for 300 seconds (5 minutes) for the run to finish and returns its output. If the run takes longer, the request will time out and throw an error.
 
     ## Response structure
-
     <span id="/introduction/response-structure"></span>
-
     Most API endpoints return a JSON object with the `data` property:
 
-
     ```
-
     {
         "data": {
             ...
         }
     }
-
     ```
-
 
     However, there are a few explicitly described exceptions, such as
-
     Dataset [Get items](#/reference/datasets/item-collection/get-items) or
-
-    Key-value store [Get record](#/reference/key-value-stores/record/get-record)
-    API endpoints,
-
+    Key-value store [Get record](#/reference/key-value-stores/record/get-record) API endpoints,
     which return data in other formats.
 
-
-    In case of an error, the response has the HTTP status code in the range of
-    4xx or 5xx
-
+    In case of an error, the response has the HTTP status code in the range of 4xx or 5xx
     and the `data` property is replaced with `error`. For example:
 
-
     ```
-
     {
         "error": {
             "type": "record-not-found",
             "message": "Store was not found."
         }
     }
-
     ```
-
 
     See [Errors](#/introduction/errors) for more details.
 
-
     ## Pagination
-
     <span id="/introduction/pagination"></span>
-
     All API endpoints that return a list of records
-
-    (e.g. [Get list of
-    actors](#/reference/actors/actor-collection/get-list-of-actors))
-
+    (e.g. [Get list of actors](#/reference/actors/actor-collection/get-list-of-actors))
     enforce pagination in order to limit the size of their responses.
 
-
-    Most of these API endpoints are paginated using the `offset` and `limit`
-    query parameters.
-
-    The only exception is [Get list of
-    keys](#/reference/key-value-stores/key-collection/get-list-of-keys),
-
+    Most of these API endpoints are paginated using the `offset` and `limit` query parameters.
+    The only exception is [Get list of keys](#/reference/key-value-stores/key-collection/get-list-of-keys),
     which is paginated using the `exclusiveStartKey` query parameter.
 
-
-    **IMPORTANT**: Each API endpoint that supports pagination enforces a certain
-    maximum value for the `limit` parameter,
-
+    **IMPORTANT**: Each API endpoint that supports pagination enforces a certain maximum value for the `limit` parameter,
     in order to reduce the load on Apify servers.
-
     The maximum limit could change in future so you should never
-
     rely on a specific value and check the responses of these API endpoints.
 
-
     ### Using offset
-
     <span id="/introduction/pagination/using-offset"></span>
-
-    Most API endpoints that return a list of records enable pagination using the
-    following query parameters:
-
+    Most API endpoints that return a list of records enable pagination using the following query parameters:
 
     <table>
       <tr>
@@ -271,13 +143,9 @@ info:
       </tr>
     </table>
 
-
-    The response of these API endpoints is always a JSON object with the
-    following structure:
-
+    The response of these API endpoints is always a JSON object with the following structure:
 
     ```
-
     {
         "data": {
             "total": 2560,
@@ -293,12 +161,9 @@ info:
             ]
         }
     }
-
     ```
 
-
     The following table describes the meaning of the response properties:
-
 
     <table>
       <tr>
@@ -334,23 +199,13 @@ info:
       </tr>
     </table>
 
-
     ### Using key
-
     <span id="/introduction/pagination/using-key"></span>
-
-    The records in the [key-value
-    store](https://docs.apify.com/platform/storage/key-value-store)
-
+    The records in the [key-value store](https://docs.apify.com/platform/storage/key-value-store)
     are not ordered based on numerical indexes,
-
     but rather by their keys in the UTF-8 binary order.
-
-    Therefore the [Get list of
-    keys](#/reference/key-value-stores/key-collection/get-list-of-keys)
-
+    Therefore the [Get list of keys](#/reference/key-value-stores/key-collection/get-list-of-keys)
     API endpoint only supports pagination using the following query parameters:
-
 
     <table>
       <tr>
@@ -364,13 +219,9 @@ info:
       </tr>
     </table>
 
-
-    The response of the API endpoint is always a JSON object with following
-    structure:
-
+    The response of the API endpoint is always a JSON object with following structure:
 
     ```
-
     {
         "data": {
             "limit": 1000,
@@ -385,12 +236,9 @@ info:
             ]
         }
     }
-
     ```
 
-
     The following table describes the meaning of the response properties:
-
 
     <table>
       <tr>
@@ -417,40 +265,24 @@ info:
       </tr>
     </table>
 
-
     ## Errors
-
     <span id="/introduction/errors"></span>
-
-    The Apify API uses common HTTP status codes: `2xx` range for success, `4xx`
-    range for errors caused by the caller
-
+    The Apify API uses common HTTP status codes: `2xx` range for success, `4xx` range for errors caused by the caller
     (invalid requests) and `5xx` range for server errors (these are rare).
-
-    Each error response contains a JSON object defining the `error` property,
-    which is an object with
-
-    the `type` and `message` properties that contain the error code and a
-    human-readable error description, respectively.
-
+    Each error response contains a JSON object defining the `error` property, which is an object with
+    the `type` and `message` properties that contain the error code and a human-readable error description, respectively.
     For example:
 
-
     ```
-
     {
         "error": {
             "type": "record-not-found",
             "message": "Store was not found."
         }
     }
-
     ```
 
-
-    Here is the table of the most common errors that can occur for many API
-    endpoints:
-
+    Here is the table of the most common errors that can occur for many API endpoints:
 
     <table>
       <tr>
@@ -495,49 +327,26 @@ info:
       </tr>
     </table>
 
-
     ## Rate limiting
-
     <span id="/introduction/rate-limiting"></span>
-
     All API endpoints limit the rate of requests in order to prevent overloading of Apify servers by misbehaving clients.
-
     There are two kinds of rate limits - a global rate limit and a per-resource rate limit.
-
     ### Global rate limit
-
     <span id="/introduction/rate-limiting/global-rate-limit"></span>
-
-    The global rate limit is set to _250 000 requests per minute_.
-    For [authenticated](#/introduction/authentication) requests, it is counted per user,
-    and for unauthenticated requests, it is counted per IP address.
-
+    The global rate limit is set to _250 000 requests per minute_. For [authenticated](#/introduction/authentication) requests, it is counted per user, and for unauthenticated requests, it is counted per IP address.
     ### Per-resource rate limit
-
     <span id="/introduction/rate-limiting/per-resource-rate-limit"></span>
-
-    The default per-resource rate limit is _30 requests per second per resource_, which in this context means a single Actor, a single Actor run, a single dataset, single key-value store etc.
-    The default rate limit is applied to every API endpoint except a few select ones, which have higher rate limits.
-    Each API endpoint returns its rate limit in `X-RateLimit-Limit` header.
-
+    The default per-resource rate limit is _30 requests per second per resource_, which in this context means a single Actor, a single Actor run, a single dataset, single key-value store etc. The default rate limit is applied to every API endpoint except a few select ones, which have higher rate limits. Each API endpoint returns its rate limit in `X-RateLimit-Limit` header.
     These endpoints have a rate limit of _100 requests per second per resource_:
-
     * CRUD ([get](#/reference/key-value-stores/record/get-record),
       [put](#/reference/key-value-stores/record/put-record),
       [delete](#/reference/key-value-stores/record/delete-record))
     operations on key-value store records
-
-    These endpoints have a rate limit of _200 requests per second per resource_:
-    * [Run actor](#/reference/actors/run-collection/run-actor)
-
+    These endpoints have a rate limit of _200 requests per second per resource_: * [Run actor](#/reference/actors/run-collection/run-actor)
     * [Run actor task asynchronously](#/reference/actor-tasks/runs-collection/run-task-asynchronously)
-
     * [Run actor task synchronously](#/reference/actor-tasks/runs-collection/run-task-synchronously)
-
     * [Metamorph actor run](#/reference/actors/metamorph-run/metamorph-run)
-
     * [Push items](#/reference/datasets/item-collection/put-items) to dataset
-
     * CRUD
       ([add](#/reference/request-queues/request-collection/add-request),
       [get](#/reference/request-queues/request-collection/get-request),
@@ -545,13 +354,9 @@ info:
       [delete](#/reference/request-queues/request-collection/delete-request))
       operations on requests in request queues
 
-    ### Rate limit exceeded errors
-    <span id="/introduction/rate-limiting/rate-limit-exceeded-errors"></span>
-
-    If the client is sending too many requests, the API endpoints respond with the HTTP status code `429 Too Many Requests`
-    and the following body:
-
-    ```
+    ### Rate limit exceeded errors <span id="/introduction/rate-limiting/rate-limit-exceeded-errors"></span>
+    If the client is sending too many requests, the API endpoints respond with the HTTP status code `429 Too Many Requests` and the following body:
+    ``` 
     {
         "error": {
             "type": "rate-limit-exceeded",
@@ -559,47 +364,25 @@ info:
         }
     }
     ```
-
     ### Retrying rate-limited requests with exponential backoff
-
     <span id="/introduction/rate-limiting/retrying-rate-limited-requests-with-exponential-backoff"></span>
-
-    If the client receives the rate limit error, it should wait a certain period of time and then retry the request.
-    If the error happens again, the client should double the wait period and retry the request,
-    and so on. This algorithm is known as _exponential backoff_
-    and it can be described using the following pseudo-code:
-
-    1. Define a variable `DELAY=500`
-    2. Send the HTTP request to the API endpoint
-    3. If the response has status code not equal to `429` then you are done. Otherwise:
+    If the client receives the rate limit error, it should wait a certain period of time and then retry the request. If the error happens again, the client should double the wait period and retry the request, and so on. This algorithm is known as _exponential backoff_ and it can be described using the following pseudo-code:
+    1. Define a variable `DELAY=500` 2. Send the HTTP request to the API endpoint 3. If the response has status code not equal to `429` then you are done. Otherwise:
        * Wait for a period of time chosen randomly from the interval `DELAY` to `2*DELAY` milliseconds
        * Double the future wait period by setting `DELAY = 2*DELAY`
        * Continue with step 2
 
-    If all requests sent by the client implement the above steps,
-    the client will automatically use the maximum available bandwidth for its requests.
-
-    Note that the Apify API clients [for JavaScript](https://docs.apify.com/api/client/js)
-    and [for Python](https://docs.apify.com/api/client/python)
-    use the exponential backoff algorithm transparently, so that you do not need to worry about it.
-
+    If all requests sent by the client implement the above steps, the client will automatically use the maximum available bandwidth for its requests.
+    Note that the Apify API clients [for JavaScript](https://docs.apify.com/api/client/js) and [for Python](https://docs.apify.com/api/client/python) use the exponential backoff algorithm transparently, so that you do not need to worry about it.
     ## Referring to resources
-
     <span id="/introduction/referring-to-resources"></span>
-
     There are three main ways to refer to a resource you're accessing via API.
-
 
     - the resource ID (e.g. `iKkPcIgVvwmztduf8`)
 
+    - `username~resourcename` - when using this access method, you will need to use your API token, and access will only work if you have the correct permissions.
 
-    - `username~resourcename` - when using this access method, you will need to
-    use your API token, and access will only work if you have the correct
-    permissions.
-
-
-    - `~resourcename` - for this, you need to use an API token, and the
-    `resourcename` refers to a resource in the API token owner's account.
+    - `~resourcename` - for this, you need to use an API token, and the `resourcename` refers to a resource in the API token owner's account.
   contact: {}
   version: ''
 servers:


### PR DESCRIPTION
I've converted the `.info.description` block to address the broken formatting of GFM fenced code block. The change makes the YAML string under the key work as a normal Markdown.

It's a simple trick: using of `description: |` instead of `description: >-`. But then the entire multi-line string needs to be rewritten/converted to omit the unnecessary newlines. I used [this dirty script to do the job](https://gist.github.com/netmilk/93760fefc3607c7b3b8c56bdf24350ad).

More on the YAML mult-line behavior here: [https://yaml-multiline.info/](https://yaml-multiline.info/)



**After**
<img width="1459" alt="Screenshot 2024-11-28 at 11 23 03" src="https://github.com/user-attachments/assets/32ebc239-4d93-4edc-8c19-a2b7d595ee83">

**Before**
![Screenshot 2024-11-28 at 11 01 57](https://github.com/user-attachments/assets/bfb8ab6d-b8b8-495a-8593-6deba99461b7)



